### PR TITLE
Skip tests on release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
-name: Continuous Build Docker
+# yamllint --format github .github/workflows/ci.yml
+---
+name: Continuous Integration
 
-# Trigger on pushes or pull requests to the master branch, but not for documentation-only updates.
+# Trigger on pushes or pull requests to the master branch, but not doc-only
 on:
   push:
     branches: master
@@ -11,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04 # aka focal, because this is what we use in Travis
+    runs-on: ubuntu-20.04  # aka focal, because this is what we use in Travis
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -25,7 +27,7 @@ jobs:
           restore-keys: ${{ runner.os }}-docker
       - name: Test
         # Skips tests on release tags
-        if: !startsWith(github.ref, 'refs/tags')
+        if: "!startsWith(github.ref, 'refs/tags')"
         run: |
-         build-bin/configure_test
-         build-bin/test
+          build-bin/configure_test
+          build-bin/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04  # aka focal, because this is what we use in Travis
+    runs-on: ubuntu-20.04  # newest available distribution, aka focal
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
-          fetch-depth: 10
+          # license-maven-plugin needs the full history to generate copyright
+          # year range. Ex. 2013-2020. Don't do a shallow clone!
+          fetch-depth: 0
       - name: Cache docker
         uses: actions/cache@v1
         with:
@@ -26,7 +28,8 @@ jobs:
           key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
           restore-keys: ${{ runner.os }}-docker
       - name: Test
-        # Skips tests on release tags
+        # We run tests on non-tagged pushes on pull requests targeted at the
+        # master branch.
         if: "!startsWith(github.ref, 'refs/tags')"
         run: |
           build-bin/configure_test

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -10,9 +10,7 @@ on:
     paths-ignore: '**/*.md'
 
 jobs:
-  test:
-    # Don't run on release tags
-    if: !contains(github.ref, 'refs/tags')
+  build:
     runs-on: ubuntu-20.04 # aka focal, because this is what we use in Travis
     steps:
       - name: Checkout Repository
@@ -25,7 +23,9 @@ jobs:
           path: ~/.docker
           key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
           restore-keys: ${{ runner.os }}-docker
-      - name: Configure test
-        run: build-bin/configure_test
       - name: Test
-        run: build-bin/test
+        # Skip tests on release tag
+        if: !contains(github.ref, 'refs/tags')
+        run:
+         - build-bin/configure_test
+         - build-bin/test

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -11,17 +11,14 @@ on:
 
 jobs:
   test:
+    # Don't run on release tags
+    if: !contains(github.ref, 'refs/tags')
     runs-on: ubuntu-20.04 # aka focal, because this is what we use in Travis
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 10
-      # Remove apt repos that are known to break from time to time.
-      # See https://github.com/actions/virtual-environments/issues/323
-      - name: Remove broken apt repos [Ubuntu]
-        run: |
-          for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
       - name: Cache docker
         uses: actions/cache@v1
         with:

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -24,8 +24,7 @@ jobs:
           key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
           restore-keys: ${{ runner.os }}-docker
       - name: Test
-        # Skip tests on release tag
-        if: !contains(github.ref, 'refs/tags')
+        if: !contains(github.ref, 'refs/tags') # Skip tests on release tag
         run:
          - build-bin/configure_test
          - build-bin/test

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -24,7 +24,7 @@ jobs:
           key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
           restore-keys: ${{ runner.os }}-docker
       - name: Test
-        if: !contains(github.ref, 'refs/tags') # Skip tests on release tag
+        if: !startsWith(github.ref, 'refs/tags')
         run:
          - build-bin/configure_test
          - build-bin/test

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -24,7 +24,8 @@ jobs:
           key: ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile') }}
           restore-keys: ${{ runner.os }}-docker
       - name: Test
+        # Skips tests on release tags
         if: !startsWith(github.ref, 'refs/tags')
-        run:
-         - build-bin/configure_test
-         - build-bin/test
+        run: |
+         build-bin/configure_test
+         build-bin/test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 The OpenZipkin Authors
+# Copyright 2015-2020 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -35,8 +35,8 @@ COPY --from=scratch /code/ .
 # Alpine's minirootfs is mirrored and only 5MB. Build on demand instead of consuming docker.io pulls
 WORKDIR /install
 # Use current version here: https://alpinelinux.org/downloads/
-ARG version=3.12.1
-ENV ALPINE_VERSION=$version
+ARG alpine_version=3.12.1
+ENV ALPINE_VERSION=$alpine_version
 RUN /code/alpine_minirootfs $ALPINE_VERSION
 
 # Define base layer, notably not adding labels always overridden

--- a/alpine_minirootfs
+++ b/alpine_minirootfs
@@ -13,7 +13,7 @@
 # the License.
 #
 
-set -eux
+set -eu
 
 # This downloads and extracts the indicated version alpine-minirootfs into the current directory.
 
@@ -41,4 +41,5 @@ case ${arch} in
     exit 1;
 esac
 
+echo "Extracting alpine-minirootfs v${full_version} for ${arch} architecture"
 wget -qO- https://dl-cdn.alpinelinux.org/alpine/v${version}/releases/${arch}/alpine-minirootfs-${version}.${patch}-${arch}.tar.gz| tar xz

--- a/build-bin/deploy
+++ b/build-bin/deploy
@@ -27,6 +27,10 @@ set -ue
 
 version=${1:-master}
 
+if [ "${version}" != "master" ]; then
+  export ALPINE_VERSION=${version}
+fi
+
 # Base layers are not pushed to Docker Hub (docker.io)
 export DOCKER_RELEASE_REPOS=ghcr.io
 export DOCKER_FILE=Dockerfile

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -23,7 +23,11 @@ if ! test -f ${docker_file}; then
   >&2 echo "${docker_file} doesn't exist"
   exit 1
 fi
-docker_args="-f ${docker_file}"
+
+# Add default labels for the day and the SHA we're building from
+docker_args="-f ${docker_file} \
+--label org.opencontainers.image.created=$(date +%Y-%m-%d) \
+--label org.opencontainers.image.revision=$(git rev-parse --short HEAD)"
 
 version=${1:-}
 if [ -n "${version}" ]; then

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -41,6 +41,12 @@ if [ -n "${DOCKER_TARGET}" ]; then
   docker_args="${docker_args} --target ${DOCKER_TARGET}"
 fi
 
+# When non-empty, becomes the build-arg alpine_version. Ex. "3.12.1"
+# Used to align base layers from https://github.com/orgs/openzipkin/packages/container/package/alpine
+if [ -n "${ALPINE_VERSION}" ]; then
+  docker_args="${docker_args} --build-arg alpine_version=${ALPINE_VERSION}"
+fi
+
 # When non-empty, becomes the build-arg java_version. Ex. "15.0.1_p9"
 # Used to align base layers from https://github.com/orgs/openzipkin/packages/container/package/java
 if [ -n "${JAVA_VERSION}" ]; then


### PR DESCRIPTION
Save overhead by not re-testing the same commit that was already
tested on master. This matches travis behaviour.