### PR TITLE
Uses --pull to ensure stale base layers aren't used on push

### DIFF
--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -64,7 +64,8 @@ echo "Will push the following tags with platform ${docker_platforms}:${tags}\n"
 
 docker_args=$($(dirname "$0")/docker_args ${version})
 
-docker_push="docker buildx build --progress plain --platform=${docker_platforms} ${docker_args} . --push"
+# --pull ensures that pushed builds don't depend on cached layers, for example, if the same image is re-pushed.
+docker_push="docker buildx build --progress plain --platform=${docker_platforms} ${docker_args} . --pull --output=type=registry"
 
 for tag in $(echo ${tags}|xargs); do
   echo "Pushing tag ${tag}..."


### PR DESCRIPTION
This doesn't impact this repo as its base is "scratch" this is for consistency