### PR TITLE
Stops using buildx completely

### DIFF
--- a/build-bin/docker/configure_docker_push
+++ b/build-bin/docker/configure_docker_push
@@ -46,21 +46,9 @@ if [ -n "${DOCKERHUB_USER:-}" ]; then
   echo "${DOCKERHUB_TOKEN}" | docker login -u "${DOCKERHUB_USER}" --password-stdin
 fi
 
-# Connection resets are frequent in GitHub Actions workflows
-alias wget="wget --random-wait --tries=5 -qO-"
-
-# Latest version from https://github.com/docker/buildx/releases
-buildx_version=0.4.2
-buildx_url=https://github.com/docker/buildx/releases/download/v${buildx_version}/buildx-v${buildx_version}.linux-${arch}
-mkdir -p $HOME/.docker/cli-plugins
-( cd $HOME/.docker/cli-plugins && wget ${buildx_url} > docker-buildx && chmod 755 docker-buildx)
-docker version
-
 # Enable execution of different multi-architecture containers by QEMU and binfmt_misc
 # See https://github.com/multiarch/qemu-user-static
 #
 # Mirrored image use to avoid docker.io pulls:
 # docker tag multiarch/qemu-user-static:5.1.0-7 ghcr.io/openzipkin/multiarch-qemu-user-static:latest
 docker run --rm --privileged ghcr.io/openzipkin/multiarch-qemu-user-static --reset -p yes
-# don't fail if there's already a builder
-docker buildx create --name builder --use || true

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -89,7 +89,7 @@ for tag in $(echo ${tags} | xargs); do
   docker manifest create ${tag} ${manifest_tags}
 
   for manifest_tag in ${manifest_tags}; do
-    docker_arch=$(echo ${arch_tag} | cut -f2 -d: | cut -f2 -d-)
+    docker_arch=$(echo ${manifest_tag} | cut -f2 -d: | cut -f2 -d-)
     docker manifest annotate ${tag} ${manifest_tag} --os linux --arch ${docker_arch}
   done
 

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -23,6 +23,7 @@ set -ue
 
 docker_image=${1?docker_image is required, notably without a tag. Ex openzipkin/zipkin}
 version=${2:-master}
+export DOCKER_BUILDKIT=0
 
 case ${version} in
   master )
@@ -58,16 +59,40 @@ for repo in ${docker_repos}; do
   done
 done
 
-# plaforms to eventually push to the registry
-docker_platforms=${DOCKER_PLATFORMS:-linux/amd64,linux/arm64,linux/s390x}
-
-echo "Will push the following tags with platform ${docker_platforms}:${tags}\n"
-
 docker_args=$($(dirname "$0")/docker_args ${version})
+docker_archs=${DOCKER_PLATFORMS:-amd64 arm64 s390x}
 
-docker_push="docker buildx build --pull --progress plain --platform=${docker_platforms} ${docker_args} . --output=type=registry"
+echo "Will build the following architectures: ${docker_archs}"
 
-for tag in $(echo ${tags}|xargs); do
-  echo "Pushing tag ${tag}..."
-  ${docker_push} --tag ${tag}
+docker_tag0="$(echo ${docker_tags} | awk '{print $1;}')"
+arch_tags=""
+for docker_arch in ${docker_archs}; do
+  arch_tag=${docker_image}:${docker_tag0}-${docker_arch}
+  echo "Building tag ${arch_tag}..."
+  docker build --pull ${docker_args} --platform linux/${docker_arch} --tag ${arch_tag} .
+  arch_tags="${arch_tags} ${arch_tag}"
+done
+
+echo "Will push the following tags:\n${tags}"
+
+for tag in $(echo ${tags} | xargs); do
+  manifest_tags=""
+  for arch_tag in ${arch_tags}; do
+    docker_arch=$(echo ${arch_tag} | cut -f2 -d: | cut -f2 -d-)
+    manifest_tag=${tag}-${docker_arch}
+    docker tag ${arch_tag} ${manifest_tag}
+    echo "Pushing tag ${manifest_tag}..."
+    docker push ${manifest_tag}
+    manifest_tags="${manifest_tags} ${manifest_tag}"
+  done
+
+  docker manifest create ${tag} ${manifest_tags}
+
+  for manifest_tag in ${manifest_tags}; do
+    docker_arch=$(echo ${arch_tag} | cut -f2 -d: | cut -f2 -d-)
+    docker manifest annotate ${tag} ${manifest_tag} --os linux --arch ${docker_arch}
+  done
+
+  echo "Pushing manifest ${manifest_tag}..."
+  docker manifest push -p ${tag}
 done


### PR DESCRIPTION
In openzipkin/zipkin, it is frequently the case that buildx uses the
wrong image for cassandra (the jre not the JDK) when arm64. This moves
to the older but more direct manifest approach to assembling multi-arch
images until buildx matures.