### PR TITLE
Always use build kit on deploy

### DIFF
--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -27,7 +27,10 @@ set -ue
 
 docker_image=${1?docker_image is required, notably without a tag. Ex openzipkin/zipkin}
 version=${2:-master}
-export DOCKER_BUILDKIT=0
+
+# We don't need build kit, but Docker 20.10 no longer accepts --platform without it.
+# It is simpler to just always enable it. See https://github.com/moby/moby/issues/41552
+export DOCKER_BUILDKIT=1
 
 case ${version} in
   master )
@@ -73,7 +76,7 @@ arch_tags=""
 for docker_arch in ${docker_archs}; do
   arch_tag=${docker_image}:${docker_tag0}-${docker_arch}
   echo "Building tag ${arch_tag}..."
-  docker build --pull ${docker_args} --platform linux/${docker_arch} --tag ${arch_tag} .
+  docker build --progress=plain --pull ${docker_args} --platform linux/${docker_arch} --tag ${arch_tag} .
   arch_tags="${arch_tags} ${arch_tag}"
 done
 


### PR DESCRIPTION
Using Docker 20.10 commands we used before now break like this:

```
image with reference sha256:6deb7d92f59f205ddaf95230bec403fd117ab8f509074f09a3fc6b108276d744 was found but does not match the specified platform: wanted linux/arm64, actual: linux/amd64
```

This switches to always use BUILDKIT=1 when pushing images, as Docker
changed behavior in 20.10 and it is more complex to figure out if we are
20.10 or not, and would be annoying to figure out what later versions
would do.

See https://github.com/moby/moby/issues/41552