### PR TITLE
Remove support for ppc64le

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY . /code/
 
 # See from a previously published version to avoid pulling from Docker Hub (docker.io)
 # This version is only used to install the real version
-FROM alpine:3.15.3 as install
+FROM ghcr.io/openzipkin/alpine:3.15.3 as install
 
 WORKDIR /code
 # Conditions aren't supported in Dockerfile instructions, so we copy source even if it isn't used.

--- a/build-bin/docker/docker_arch
+++ b/build-bin/docker/docker_arch
@@ -38,9 +38,6 @@ case ${docker_arch} in
   s390x* )
     docker_arch=s390x
     ;;
-  ppc64le* )
-    docker_arch=ppc64le
-    ;;
   * )
     >&2 echo "Unsupported DOCKER_ARCH: ${docker_arch}"
     exit 1;

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -64,7 +64,7 @@ for repo in ${docker_repos}; do
 done
 
 docker_args=$($(dirname "$0")/docker_args ${version})
-docker_archs=${DOCKER_ARCHS:-amd64 arm64 s390x ppc64le}
+docker_archs=${DOCKER_ARCHS:-amd64 arm64 s390x}
 
 echo "Will build the following architectures: ${docker_archs}"
 


### PR DESCRIPTION
There is a failure when building container for ppc64le

There isn't a clear workaround so going to remove this as a supported arch
util that can be resolved.