### PR TITLE
Add ca-certificates and fix building on Mac OS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN \
   # * libcrypto1.1, libssl1.1: Fix CVE-2022-2097
   # * busybox: Fix CVE-2022-30065
   # * ssl_client: Fix CVE-2022-30065
-  apk add --no-cache java-cacerts libc6-compat libcrypto1.1=1.1.1q-r0 libssl1.1=1.1.1q-r0 busybox=1.35.0-r17 ssl_client=1.35.0-r17 && \
+  apk add --no-cache java-cacerts ca-certificates libc6-compat libcrypto1.1=1.1.1q-r3 libssl1.1=1.1.1q-r3 busybox=1.35.0-r22 ssl_client=1.35.0-r22 && \
   #
   # Typically, only amd64 is tested in CI: Run a command to ensure binaries match current arch.
   ldd /lib/libz.so.1

--- a/build-bin/docker/docker_build
+++ b/build-bin/docker/docker_build
@@ -20,4 +20,4 @@ version=${2:-}
 docker_args=$($(dirname "$0")/docker_args ${version})
 
 echo "Building image ${docker_tag}"
-DOCKER_BUILDKIT=1 docker build --pull ${docker_args} --tag ${docker_tag} .
+DOCKER_BUILDKIT=1 docker build --network=host --pull ${docker_args} --tag ${docker_tag} .


### PR DESCRIPTION
- Java build appears to be failing with missing CA certs so adding those
- Local build fails on Mac OS. Adding --network=host to build command fixes