### PR TITLE
Upgrade packages to get off libcrypto1.1 which as a number of CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY . /code/
 
 # See from a previously published version to avoid pulling from Docker Hub (docker.io)
 # This version is only used to install the real version
-FROM ghcr.io/openzipkin/alpine:3.16.0 as install
+FROM ghcr.io/openzipkin/alpine:3.16.2 as install
 
 WORKDIR /code
 # Conditions aren't supported in Dockerfile instructions, so we copy source even if it isn't used.
@@ -74,11 +74,11 @@ RUN \
   # Finalize install:
   # * java-cacerts: implicitly gets normal ca-certs used outside Java (this does not depend on java)
   # * libc6-compat: BoringSSL for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
-  # * libcrypto1.1, libssl1.1: Fix CVE-2022-2097
-  # * busybox: Fix CVE-2022-30065
-  # * ssl_client: Fix CVE-2022-30065
-  apk add --no-cache java-cacerts ca-certificates libc6-compat libcrypto1.1=1.1.1q-r0 libssl1.1=1.1.1q-r0 busybox=1.35.0-r17 ssl_client=1.35.0-r17 && \
-  #
+  apk add --no-cache java-cacerts ca-certificates libc6-compat && \
+  # * upgrade available to fix CVEs CVE-2021-4044, CVE-2022-0778, CVE-2022-1473, CVE-2022-3358, CVE-2022-3602, CVE-2022-3786
+  #   currently there are lots of dependencies on libcrypto1.1 and necessary fixes require moving to libcrypto3.
+  #   note: this is temporary and next Alpine after 3.16.2 should have necessary fixes in place.
+  apk upgrade --available --no-cache && \
   # Typically, only amd64 is tested in CI: Run a command to ensure binaries match current arch.
   ldd /lib/libz.so.1
 

--- a/alpine_minirootfs
+++ b/alpine_minirootfs
@@ -17,7 +17,7 @@ set -eu
 
 # This downloads and extracts the indicated version alpine-minirootfs into the current directory.
 
-full_version=${1?full_version ex 3.12.3}
+full_version=${1?full_version ex 3.16.2}
 version=$(echo "${full_version}" | sed -En "s/^([0-9]+\.[0-9]+)\.[0-9]+$/\1/p")
 patch=$(echo "${full_version}" | cut -f3 -d.)
 


### PR DESCRIPTION
Tried replacing libcrypto1.1 with libcrypto3 but there are a lot of dependencies which use the former. Next Alpine release should have everything switched over to libcrypto3 but for now I was only successful after doing an upgrade on all available packages.

Fixes:
CVE-2021-4044
CVE-2022-0778
CVE-2022-1473
CVE-2022-3358
CVE-2022-3602
CVE-2022-3786
CVE-2022-1343
CVE-2022-1434
CVE-2022-2097