### PR TITLE
Upgrade to Alpine 3.17 which uses OpenSSL v3 instead of v1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # When updating, update the README and the alpine_version ARG
 #  * Use current version from https://alpinelinux.org/downloads/
 #  * ARGs repeat because Dockerfile ARGs are layer specific but will reuse the value defined here.
-ARG alpine_version=3.16.2
+ARG alpine_version=3.17.0
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
@@ -75,10 +75,6 @@ RUN \
   # * java-cacerts: implicitly gets normal ca-certs used outside Java (this does not depend on java)
   # * libc6-compat: BoringSSL for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
   apk add --no-cache java-cacerts ca-certificates libc6-compat && \
-  # * upgrade available to fix CVEs CVE-2021-4044, CVE-2022-0778, CVE-2022-1473, CVE-2022-3358, CVE-2022-3602, CVE-2022-3786
-  #   currently there are lots of dependencies on libcrypto1.1 and necessary fixes require moving to libcrypto3.
-  #   note: this is temporary and next Alpine after 3.16.2 should have necessary fixes in place.
-  apk upgrade --available --no-cache && \
   # Typically, only amd64 is tested in CI: Run a command to ensure binaries match current arch.
   ldd /lib/libz.so.1
 

--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ This is an internal base layer primarily used in [docker-java](https://github.co
 
 To browse the image, run it in interactive mode with TTY enabled like so:
 ```bash
-docker run -ti --rm ghcr.io/openzipkin/alpine:3.16.2
+docker run -ti --rm ghcr.io/openzipkin/alpine:3.17.0
 / #
 ```
 
 ## Release process
 Build the `Dockerfile` using the current version from https://alpinelinux.org/downloads/:
 ```bash
-# Note 3.16.2 not 3.16!
-./build-bin/build 3.16.2
+# Note 3.17.0 not 3.17!
+./build-bin/build 3.17.0
 ```
 
 Next, verify the built image matches that version:
 ```bash
 docker run --rm openzipkin/alpine:test -c 'cat /etc/alpine-release'
-3.16.2
+3.17.0
 ```
 
-To release the image, push a tag matching the arg to `build-bin/build` (ex `3.16.2`).
+To release the image, push a tag matching the arg to `build-bin/build` (ex `3.17.0`).
 This triggers a [GitHub Actions](https://github.com/openzipkin/docker-alpine/actions) job to push the image.

--- a/alpine_minirootfs
+++ b/alpine_minirootfs
@@ -17,7 +17,7 @@ set -eu
 
 # This downloads and extracts the indicated version alpine-minirootfs into the current directory.
 
-full_version=${1?full_version ex 3.16.2}
+full_version=${1?full_version ex 3.17.0}
 version=$(echo "${full_version}" | sed -En "s/^([0-9]+\.[0-9]+)\.[0-9]+$/\1/p")
 patch=$(echo "${full_version}" | cut -f3 -d.)
 


### PR DESCRIPTION
3.17 now uses OpenSSL v3 as default which fixes the following CVEs without using packages from Edge release. CVEs CVE-2021-4044, CVE-2022-0778, CVE-2022-1473, CVE-2022-3358, CVE-2022-3602, CVE-2022-3786