### PR TITLE
Updates to alpine 3.18.5 and removes explicit crypto install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # When updating, update the README and the alpine_version ARG
 #  * Use current version from https://alpinelinux.org/downloads/
 #  * ARGs repeat because Dockerfile ARGs are layer specific but will reuse the value defined here.
-ARG alpine_version=3.18.2
+ARG alpine_version=3.18.5
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
@@ -75,8 +75,6 @@ RUN \
   # * java-cacerts: implicitly gets normal ca-certs used outside Java (this does not depend on java)
   # * libc6-compat: BoringSSL for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
   apk add --no-cache java-cacerts ca-certificates libc6-compat && \
-  # Force install versions that don't have CVE-2023-2975. This can be removed on future versions.
-  apk add --no-cache libcrypto3=3.1.1-r3 libssl3=3.1.1-r3 && \
   # Typically, only amd64 is tested in CI: Run a command to ensure binaries match current arch.
   ldd /lib/libz.so.1
 


### PR DESCRIPTION
This updates from 3.18.2 to 3.18.5, released a few days ago

https://git.alpinelinux.org/aports/log/?h=v3.18.3
https://git.alpinelinux.org/aports/log/?h=v3.18.4
https://git.alpinelinux.org/aports/log/?h=v3.18.5

This shows we don't need to force install to get at least 3.1.1-r3
```bash
$ docker run --rm openzipkin/alpine:test -c 'apk info libssl3'
WARNING: opening from cache https://dl-cdn.alpinelinux.org/alpine/v3.18/main: No such file or directory
WARNING: opening from cache https://dl-cdn.alpinelinux.org/alpine/v3.18/community: No such file or directory
WARNING: opening from cache https://dl-cdn.alpinelinux.org/alpine/edge/main: No such file or directory
WARNING: opening from cache https://dl-cdn.alpinelinux.org/alpine/edge/testing: No such file or directory
WARNING: opening from cache https://dl-cdn.alpinelinux.org/alpine/edge/community: No such file or directory
libssl3-3.1.4-r1 description:
SSL shared libraries

libssl3-3.1.4-r1 webpage:
https://www.openssl.org/

libssl3-3.1.4-r1 installed size:
608 KiB
```