### PR TITLE
Updates to Alpine 3.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # When updating, update the README and the alpine_version ARG
 #  * Use current version from https://alpinelinux.org/downloads/
 #  * ARGs repeat because Dockerfile ARGs are layer specific but will reuse the value defined here.
-ARG alpine_version=3.18.5
+ARG alpine_version=3.19.0
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.

--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ This is an internal base layer primarily used in [docker-java](https://github.co
 
 To browse the image, run it in interactive mode with TTY enabled like so:
 ```bash
-docker run -ti --rm ghcr.io/openzipkin/alpine:3.18.5
+docker run -ti --rm ghcr.io/openzipkin/alpine:3.19.0
 / #
 ```
 
 ## Release process
 Build the `Dockerfile` using the current version from https://alpinelinux.org/downloads/:
 ```bash
-# Note 3.18.5 not 3.18!
-./build-bin/build 3.18.5
+# Note 3.19.0 not 3.18!
+./build-bin/build 3.19.0
 ```
 
 Next, verify the built image matches that version:
 ```bash
 docker run --rm openzipkin/alpine:test -c 'cat /etc/alpine-release'
-3.18.5
+3.19.0
 ```
 
-To release the image, push a tag matching the arg to `build-bin/build` (ex `3.18.5`).
+To release the image, push a tag matching the arg to `build-bin/build` (ex `3.19.0`).
 This triggers a [GitHub Actions](https://github.com/openzipkin/docker-alpine/actions) job to push the image.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ docker run -ti --rm ghcr.io/openzipkin/alpine:3.19.0
 ## Release process
 Build the `Dockerfile` using the current version from https://alpinelinux.org/downloads/:
 ```bash
-# Note 3.19.0 not 3.18!
+# Note 3.19.0 not 3.19!
 ./build-bin/build 3.19.0
 ```
 


### PR DESCRIPTION
https://www.alpinelinux.org/posts/Alpine-3.19.0-released.html

```bash
$ docker run --rm openzipkin/alpine:test -c 'cat /etc/alpine-release'
3.19.0
```