### PR TITLE
Addresses comment drift on libc6-compat vs gcompat

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://github.com/openzipkin/docker-alpine/workflows/test/badge.svg)](https://github.com/openzipkin/docker-alpine/actions?query=workflow%3Atest)
 
 `ghcr.io/openzipkin/alpine` is a minimal [Alpine Linux](https://alpinelinux.org) image including
-CA certs and libc6-compat.
+CA certs and gcompat.
 
 GitHub Container Registry: [ghcr.io/openzipkin/alpine](https://github.com/orgs/openzipkin/packages/container/package/alpine) includes:
  * `master` tag: latest commit

--- a/build-bin/test
+++ b/build-bin/test
@@ -7,5 +7,5 @@ echo "Building Docker image..."
 build-bin/build
 
 echo "Verifying Docker image..."
-# Invoke a binary in libc6-compat to ensure arch matches
+# Invoke a binary in gcompat to ensure arch matches
 docker run --rm openzipkin/alpine:test -c 'ldd /lib/libz.so.1'


### PR DESCRIPTION
missed from https://github.com/openzipkin/docker-alpine/pull/40