### PR TITLE
ci: tests arm64 via Apple Silicon

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04  # newest available distribution, aka jellyfish
-          - os: macos-14  # For arm64 (via Apple Silicon)
+          - os: flyci-macos-large-latest-m1  # For arm64 (via Apple Silicon)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,13 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # sometimes failures are OS specific
+      matrix:
+        include:
+          - os: ubuntu-22.04  # newest available distribution, aka jellyfish
+          - os: macos-14  # For arm64 (via Apple Silicon)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/