### PR TITLE
Uses edge repos exclusively

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
 #
-# Copyright 2015-2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 # alpine_version is hard-coded here to allow the following to work:
@@ -23,13 +14,13 @@ ARG alpine_version=3.20.3
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
 # COPY --from= works around the issue.
-FROM scratch as code
+FROM scratch AS code
 
 COPY . /code/
 
 # See from a previously published version to avoid pulling from Docker Hub (docker.io)
 # This version is only used to install the real version
-FROM ghcr.io/openzipkin/alpine:3.20.2 as install
+FROM ghcr.io/openzipkin/alpine:3.20.2 AS install
 
 WORKDIR /code
 # Conditions aren't supported in Dockerfile instructions, so we copy source even if it isn't used.
@@ -43,7 +34,7 @@ ENV ALPINE_VERSION=$alpine_version
 RUN /code/alpine_minirootfs $ALPINE_VERSION
 
 # Define base layer, notably not adding labels always overridden
-FROM scratch as alpine
+FROM scratch AS alpine
 ARG maintainer="OpenZipkin https://gitter.im/openzipkin/zipkin"
 LABEL maintainer=$maintainer
 LABEL org.opencontainers.image.authors=$maintainer
@@ -53,9 +44,9 @@ LABEL alpine-version=$alpine_version
 COPY --from=install /install /
 
 # Default to UTF-8 file.encoding
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 # RUN, COPY, and ADD instructions create layers. While layer count is less important in modern
 # Docker, it doesn't help performance to intentionally make multiple RUN layers in a base image.
@@ -65,11 +56,10 @@ RUN \
   # will throw UnknownHostException as the local hostname isn't in DNS.
   echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
   #
-  # Later installations may require more recent versions of packages such as nodejs
-  for repository in main testing community; do \
-  repository_url=https://dl-cdn.alpinelinux.org/alpine/edge/${repository} && \
-  grep -qF -- ${repository_url} /etc/apk/repositories || echo ${repository_url} >> /etc/apk/repositories; \
-  done && \
+  # Exclusively use edge repos to get recent packages, but avoid conflicts with 3.20
+  echo 'https://dl-cdn.alpinelinux.org/alpine/edge/main' > /etc/apk/repositories && \
+  echo 'https://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
+  echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories && \
   #
   # Finalize install:
   # * java-cacerts: implicitly gets normal ca-certs used outside Java (this does not depend on java)

--- a/alpine_minirootfs
+++ b/alpine_minirootfs
@@ -1,16 +1,7 @@
 #!/bin/sh
 #
-# Copyright 2023 The OpenZipkin Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 
 set -eu


### PR DESCRIPTION
advice from https://gitlab.alpinelinux.org/alpine/aports/-/issues/16625#note_457582

before it was:
```
https://dl-cdn.alpinelinux.org/alpine/v3.20/main
https://dl-cdn.alpinelinux.org/alpine/v3.20/community
https://dl-cdn.alpinelinux.org/alpine/edge/main
https://dl-cdn.alpinelinux.org/alpine/edge/testing
https://dl-cdn.alpinelinux.org/alpine/edge/community
```

now:
```
https://dl-cdn.alpinelinux.org/alpine/edge/main
https://dl-cdn.alpinelinux.org/alpine/edge/testing
https://dl-cdn.alpinelinux.org/alpine/edge/community
```